### PR TITLE
Mise à jour de l'orchestration avec la suppression du fichier config.json dans le client 

### DIFF
--- a/.env.client
+++ b/.env.client
@@ -1,0 +1,1 @@
+URL_SERVEUR=http://api.localhost:4000

--- a/README.md
+++ b/README.md
@@ -24,17 +24,9 @@ Pour déployer l'application, un *playbook* [ansible][] est fourni.
 ### Pre-requis de la machine cible
 
 La machine cible doit avoir *docker*, *docker-compose* et *git* installés.
-De plus, des fichiers de configuration doivent également être présent.
+De plus, un fichier de configuration doit également être présent.
 
-Un fichier `config.json`. Remplacer la valeur de la clef `hote_serveur`, avec l'URL du serveur qui stocke les événements.
-
-    {
-      "config": {
-        "hote_serveur": "http://localhost:3000"
-      }
-    }
-
-Et un fichier `.env.serveur.prod`. `SECRET_KEY_BASE` et `DATABASE_URL` devraient être modifiés.
+Un fichier `.env.serveur.prod`. `SECRET_KEY_BASE` et `DATABASE_URL` devraient être modifiés.
 
     SECRET_KEY_BASE=ICI_METTRE_UNE_VRAI_SECRET_KEY_BASE
     RAILS_SERVE_STATIC_FILES=true

--- a/deploiement.yml
+++ b/deploiement.yml
@@ -12,6 +12,7 @@
       CHEMIN_CLIENT: "../{{ chemin_client }}"
       CHEMIN_SERVEUR: "../{{ chemin_serveur }}"
       CHEMIN_ACME: "../{{ chemin_acme }}"
+      URL_SERVEUR: "https://api.competences-pro.beta.gouv.fr"
 
   tasks:
     - name: Clone ou met à jour le dépot
@@ -35,12 +36,6 @@
         remote_src: yes
         src: "{{ chemin_config }}/.env.serveur.prod"
         dest: "{{ chemin_orchestrateur }}/.env.serveur.prod"
-
-    - name: Copie le fichier de configuration du client
-      copy:
-        remote_src: yes
-        src: "{{ chemin_config }}/config.json"
-        dest: "{{ chemin_client }}/config.json"
 
     - name: Crée le dossier acme
       file:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,6 +15,8 @@ services:
     image: node:10
     volumes:
       - ${CHEMIN_CLIENT}:/app
+    env_file:
+      - .env.client
     working_dir: /app
     command: npm run dev
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
   client:
     build:
       context: ${CHEMIN_CLIENT}
+      args:
+        URL_SERVEUR: ${URL_SERVEUR}
     restart: always
     depends_on:
       - serveur


### PR DESCRIPTION
Dans betagouv/competences-pro#102, le fichier `config.json` a été supprimé par une variable d'environnement `URL_SERVEUR`. 
Cette PR met à jour le `docker-compose` de développement et de production pour l'injecter correctement: 

- au runtime pour le développement
- au build pour la production

Le *playbook* de déploiement a également été modifié pour ne plus copier le fichier `config.json`.