### PR TITLE
Modularisation du déploiement

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Voici la liste des variables typique à personnaliser :
 - `hote_client`
 - `hote_serveur`
 
+**Attention : il faut impérativement spécifier un `chemin_racine` différent de `{{ ansible_env.HOME }}` si on souhaite déployer d'autres versions que `master`. Dans le cas contraire, l'application pointera vers la base de données de production, avec tous les risques de corruption que cela peut entraîner.**
+
 ## Licence
 
 Ce logiciel et son code source sont distribués sous [licence AGPL](https://www.gnu.org/licenses/why-affero-gpl.fr.html).

--- a/README.md
+++ b/README.md
@@ -22,9 +22,25 @@ Et se rendre sur http://localhost:4000
 
 ## Déploiement
 
-Pour déployer l'application, un *playbook* [ansible][] est fourni.
+Pour déployer l'application, des *playbooks* [ansible][] sont fournis.
 
-### Pre-requis de la machine cible
+Pre-requis : `ansible`
+
+Créer un fichier `hotes` en rajoutant l'adresse du serveur déployé :
+
+    example.net:22
+
+## Déploiement de traefik
+
+Nous utilisons [Traefik][] pour exposer les différents containers vers l'extérieur. Vous pouvez personaliser sa configuration en éditant le fichier `traefik.toml`.
+
+Puis lancer le déploiement (avec l'utilisateur distant `utilisateur`):
+
+    ansible-playbook --user=utilisateur --inventory=hotes traefik.yml
+
+### Déploiement de l'application
+
+#### Pre-requis de la machine cible
 
 La machine cible doit avoir *docker*, *docker-compose* et *git* installés.
 De plus, un fichier de configuration doit également être présent.
@@ -36,20 +52,28 @@ Un fichier `.env.serveur.prod`. `SECRET_KEY_BASE` et `DATABASE_URL` devraient ê
     RAILS_LOG_TO_STDOUT=true
     DATABASE_URL=postgres://postgres:@postgres/postgres
 
-### Sur la machine qui fait le déploiement
+#### Sur la machine qui fait le déploiement
 
-Pre-requis : `ansible`
+Puis lancer le déploiement (avec l'utilisateur distant `utilisateur`):
 
-Créer un fichier `hotes` en rajoutant l'adresse du serveur déployé :
+    ansible-playbook --user=utilisateur --inventory=hotes deploiement.yml
 
-    example.net:22
+Il est également possible de personnaliser les chemins, les branches ou les hôtes :
 
-Puis lancer le déploiement :
+    ansible-playbook --inventory=hotes --user=utilisateur --extra-vars="chemin_racine={{ansible_env.HOME}}/preprod hote_client=preprod.competences-pro.beta.gouv.fr hote_serveur=apipreprod.competences-pro.beta.gouv.fr" deploiement.yml
 
-    ansible-playbook --user=XXX --inventory=hotes deploiement.yml
+Voici la liste des variables typique à personnaliser :
+
+- `chemin_racine`
+- `version_orchestrateur`
+- `version_serveur`
+- `version_client`
+- `hote_client`
+- `hote_serveur`
 
 ## Licence
 
 Ce logiciel et son code source sont distribués sous [licence AGPL](https://www.gnu.org/licenses/why-affero-gpl.fr.html).
 
 [ansible]: https://www.ansible.com/
+[traefik]: https://traefik.io/

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Créer un fichier `hotes` en rajoutant l'adresse du serveur déployé :
 
 Puis lancer le déploiement :
 
-    ansible-playbook --inventory=hotes deploiement.yml
+    ansible-playbook --user=XXX --inventory=hotes deploiement.yml
 
 ## Licence
 

--- a/deploiement.yml
+++ b/deploiement.yml
@@ -15,8 +15,8 @@
     docker_compose_environnement:
       CHEMIN_CLIENT: "{{ chemin_client }}"
       CHEMIN_SERVEUR: "{{ chemin_serveur }}"
-      HOTE_SERVEUR: "{{ hote_serveur }}"
       HOTE_CLIENT: "{{ hote_client }}"
+      HOTE_SERVEUR: "{{ hote_serveur }}"
       RESEAU_TRAEFIK: "traefik"
       COMPOSE_PROJECT_NAME: "{{ chemin_racine|replace('/', '-') }}"
 

--- a/deploiement.yml
+++ b/deploiement.yml
@@ -6,7 +6,7 @@
     chemin_client: "{{ chemin_racine }}/client"
     chemin_serveur: "{{ chemin_racine }}/serveur"
     chemin_orchestrateur: "{{ chemin_racine }}/orchestrateur"
-    chemin_config: "{{ chemin_racine }}/config"
+    chemin_config: "{{ ansible_env.HOME }}/config"
     version_orchestrateur: master
     version_serveur: master
     version_client: master

--- a/deploiement.yml
+++ b/deploiement.yml
@@ -1,46 +1,49 @@
 ---
 - hosts: all
-  remote_user: cpro
 
   vars:
-    chemin_client: client
-    chemin_serveur: serveur
-    chemin_orchestrateur: orchestrateur
-    chemin_config: config
-    chemin_acme: acme
+    chemin_racine: "{{ ansible_env.HOME }}"
+    chemin_client: "{{ chemin_racine }}/client"
+    chemin_serveur: "{{ chemin_racine }}/serveur"
+    chemin_orchestrateur: "{{ chemin_racine }}/orchestrateur"
+    chemin_config: "{{ chemin_racine }}/config"
+    version_orchestrateur: master
+    version_serveur: master
+    version_client: master
+    hote_client: competences-pro.beta.gouv.fr
+    hote_serveur: api.competences-pro.beta.gouv.fr
     docker_compose_environnement:
-      CHEMIN_CLIENT: "../{{ chemin_client }}"
-      CHEMIN_SERVEUR: "../{{ chemin_serveur }}"
-      CHEMIN_ACME: "../{{ chemin_acme }}"
-      URL_SERVEUR: "https://api.competences-pro.beta.gouv.fr"
+      CHEMIN_CLIENT: "{{ chemin_client }}"
+      CHEMIN_SERVEUR: "{{ chemin_serveur }}"
+      HOTE_SERVEUR: "{{ hote_serveur }}"
+      HOTE_CLIENT: "{{ hote_client }}"
+      RESEAU_TRAEFIK: "traefik"
 
   tasks:
     - name: Clone ou met à jour le dépot
       git:
         repo: "https://github.com/betagouv/{{ item.depot }}.git"
-        version: master
-        dest: "./{{ item.destination }}"
+        version: "{{ item.version }}"
+        dest: "{{ item.destination }}"
         force: yes
       loop:
         - destination: "{{ chemin_orchestrateur }}"
           depot: competences-pro-orchestrateur
+          version: "{{ version_orchestrateur }}"
 
         - destination: "{{ chemin_serveur }}"
           depot: competences-pro-serveur
+          version: "{{ version_serveur }}"
 
         - destination: "{{ chemin_client }}"
           depot: competences-pro
+          version: "{{ version_client }}"
 
     - name: Copie le fichier d'environnement de production vers l'orchestrateur
       copy:
         remote_src: yes
         src: "{{ chemin_config }}/.env.serveur.prod"
         dest: "{{ chemin_orchestrateur }}/.env.serveur.prod"
-
-    - name: Crée le dossier acme
-      file:
-        path: "{{ chemin_acme }}"
-        state: directory
 
     - name: Construis les images docker
       command: docker-compose build --pull

--- a/deploiement.yml
+++ b/deploiement.yml
@@ -18,6 +18,7 @@
       HOTE_SERVEUR: "{{ hote_serveur }}"
       HOTE_CLIENT: "{{ hote_client }}"
       RESEAU_TRAEFIK: "traefik"
+      COMPOSE_PROJECT_NAME: "{{ chemin_racine|replace('/', '-') }}"
 
   tasks:
     - name: Clone ou met à jour le dépot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,21 @@
 version: "2"
 services:
 
-  traefik:
-    image: traefik
-    volumes:
-      - ./traefik.toml:/etc/traefik/traefik.toml
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ${CHEMIN_ACME}:/etc/traefik/acme
-    ports:
-      - "443:443"
-      - "80:80"
-    restart: always
-
   client:
     build:
       context: ${CHEMIN_CLIENT}
       args:
-        URL_SERVEUR: ${URL_SERVEUR}
+        URL_SERVEUR: "https://${HOTE_SERVEUR}"
     restart: always
     depends_on:
       - serveur
+    networks:
+      - "${RESEAU_TRAEFIK}"
     labels:
       traefik.enable: 'true'
-      traefik.frontend.rule: 'Host: competences-pro.beta.gouv.fr'
+      traefik.frontend.rule: 'Host: ${HOTE_CLIENT}'
       traefik.port: '80'
+      traefik.docker.network: '${RESEAU_TRAEFIK}'
 
   serveur:
     build:
@@ -35,16 +27,27 @@ services:
     restart: always
     depends_on:
       - postgres
+    networks:
+      - "${RESEAU_TRAEFIK}"
+      - postgres
     labels:
       traefik.enable: 'true'
-      traefik.frontend.rule: 'Host: api.competences-pro.beta.gouv.fr'
+      traefik.frontend.rule: 'Host: ${HOTE_SERVEUR}'
       traefik.port: '3000'
+      traefik.docker.network: '${RESEAU_TRAEFIK}'
 
   postgres:
     image: postgres:11
     restart: always
     volumes:
       - pgdata:/var/lib/postgresql/data
+    networks:
+      - postgres
 
 volumes:
   pgdata:
+
+networks:
+  traefik:
+    external: true
+  postgres:

--- a/traefik.yml
+++ b/traefik.yml
@@ -1,0 +1,42 @@
+---
+- hosts: all
+
+  vars:
+    chemin_racine: "{{ ansible_env.HOME }}"
+    chemin_config: "{{ chemin_racine }}/traefik"
+    chemin_acme: "{{ chemin_racine }}/acme"
+
+  tasks:
+    - name: Crée les dossiers
+      file:
+        path: "{{ item }}"
+        state: directory
+      loop:
+        - "{{ chemin_acme }}"
+        - "{{ chemin_config }}"
+
+    - name: Copie le fichier de config
+      copy:
+        src: traefik.toml
+        dest: "{{ chemin_config }}"
+
+    - name: Crée le réseau traefik
+      docker_network:
+        name: traefik
+
+    - name: Démarre traefik
+      docker_container:
+        image: traefik
+        name: traefik
+        restart_policy: always
+        pull: true
+        restart: true
+        published_ports:
+          - 443:443
+          - 80:80
+        networks:
+          - name: traefik
+        volumes:
+          - "{{ chemin_config }}/traefik.toml:/etc/traefik/traefik.toml"
+          - /var/run/docker.sock:/var/run/docker.sock
+          - "{{ chemin_acme }}:/etc/traefik/acme"


### PR DESCRIPTION
Pour permettre le déploiement d'un environnement de préproduction et de branches arbitraires, j'ai modularisé un peu notre déploiement.

Tout d'abord, Traefik qui était dans le docker-compose de base qui est désormais sorti pour permettre le routage de plusieurs instances de compétences pro. Pour cela le changement a été de créer un réseau docker qui soit partagé entre les conteneurs qui exposent des choses (client et serveur).

Ensuite le playbook de déploiement a été modularisé pour variabiliser tout ce qui devait l'être.