### PR TITLE
Configure `docker-compose` pour docker-sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ hotes
 client
 serveur
 deploiement.retry
+.docker-sync

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Pour accéder à l'api, il faut rajouter une entrée dans votre fichier `/etc/ho
 
 Pour démarrer l'environnement de développement :
 
+Pre-requis Mac : `docker-sync` (install avec `gem install docker-sync`)
+
+
     git clone git@github.com:betagouv/competences-pro.git client
     git clone git@github.com:betagouv/competences-pro-serveur.git serveur
 

--- a/docker-compose-dev-base.yml
+++ b/docker-compose-dev-base.yml
@@ -13,8 +13,6 @@ services:
 
   client:
     image: node:10
-    volumes:
-      - ${CHEMIN_CLIENT}:/app
     env_file:
       - .env.client
     working_dir: /app
@@ -24,8 +22,6 @@ services:
 
   serveur:
     image: ruby:2.6
-    volumes:
-      - ${CHEMIN_SERVEUR}:/app
     env_file:
       - .env.serveur
     working_dir: /app

--- a/docker-compose-dev-linux.yml
+++ b/docker-compose-dev-linux.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  client:
+    volumes:
+      - ${CHEMIN_CLIENT}:/app
+  serveur:
+    volumes:
+      - ${CHEMIN_SERVEUR}:/app

--- a/docker-compose-dev-mac.yml
+++ b/docker-compose-dev-mac.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  client:
+    volumes:
+      - client-sync:/app:nocopy
+  serveur:
+    volumes:
+      - serveur-sync:/app:nocopy
+
+volumes:
+  client-sync:
+    external: true
+  serveur-sync:
+    external: true

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,0 +1,12 @@
+version: "2"
+syncs:
+  client-sync:
+    notify_terminal: true
+    src: ${CHEMIN_CLIENT}
+    sync_excludes: ['.gitignore', '.git', 'node_modules']
+
+  serveur-sync:
+    notify_terminal: true
+    src: ${CHEMIN_SERVEUR}
+    sync_excludes: ['.gitignore', '.git', 'vendor']
+

--- a/script/demarre
+++ b/script/demarre
@@ -2,6 +2,10 @@
 
 set -e
 
+if [ $(uname) == "Darwin" ]
+then
+  docker-sync start
+fi
 ./script/docker-compose-dev run --rm client npm install
 ./script/docker-compose-dev run --rm serveur bundle install --path vendor
 ./script/docker-compose-dev run --rm serveur bundle exec ./bin/rails db:migrate RAILS_ENV=development

--- a/script/demarre
+++ b/script/demarre
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ $(uname) == "Darwin" ]
+if [ $(uname) = "Darwin" ]
 then
   docker-sync start
 fi

--- a/script/docker-compose-dev
+++ b/script/docker-compose-dev
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 COMPOSE_FILE=docker-compose-dev-base.yml
-if [ $(uname) == "Darwin" ]
+if [ $(uname) = "Darwin" ]
 then
   COMPOSE_FILE=$COMPOSE_FILE:docker-compose-dev-mac.yml
 else

--- a/script/docker-compose-dev
+++ b/script/docker-compose-dev
@@ -1,3 +1,12 @@
 #!/bin/sh
 
-docker-compose -f docker-compose-dev.yml $@
+COMPOSE_FILE=docker-compose-dev-base.yml
+if [ $(uname) == "Darwin" ]
+then
+  COMPOSE_FILE=$COMPOSE_FILE:docker-compose-dev-mac.yml
+else
+  COMPOSE_FILE=$COMPOSE_FILE:docker-compose-dev-linux.yml
+fi
+
+export COMPOSE_FILE
+docker-compose $@


### PR DESCRIPTION
De manière à pourvoir utiliser docker aussi sur Mac, cette PR propose la configuration `docker-sync`.

Elle ajoute en pre-requis l'installation de `docker-sync` sur les mac
Pour Linux, rien ne change, `docker-sync` n'est pas utilisé.
