### PR TITLE
Paramètre le démarrage de docker-sync avec une variable système plutôt qu'en vérifiant l'os

### DIFF
--- a/script/demarre
+++ b/script/demarre
@@ -2,10 +2,11 @@
 
 set -e
 
-if [ $(uname) = "Darwin" ]
+if [ -n "$DOCKER_SYNC" ]
 then
   docker-sync start
 fi
+
 ./script/docker-compose-dev run --rm client npm install
 ./script/docker-compose-dev run --rm serveur bundle install --path vendor
 ./script/docker-compose-dev run --rm serveur bundle exec ./bin/rails db:migrate RAILS_ENV=development


### PR DESCRIPTION
fix #16