### PR TITLE
Ajoute la configuration de l'hote du serveur en dévelopemment.

### DIFF
--- a/.env.serveur
+++ b/.env.serveur
@@ -3,3 +3,4 @@ DB_HOST=postgres
 DB_PASSWORD=
 DB_USER=postgres
 JETON_SERVEUR_ROLLBAR=
+HOST_URL=http://localhost:4000


### PR DESCRIPTION
Nécessaire pour betagouv/competences-pro-serveur#120 que rails puisse construire l'url des illustrations.