### PR TITLE
supprime variable d'environnement inutilisée

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
         RAILS_ENV: production
     environment:
       HOTE_SERVEUR: "${HOTE_SERVEUR}"
-      TZ: Europe/Paris
     env_file:
       - .env.serveur.prod
     restart: always


### PR DESCRIPTION
Supprime cette variable d'environnement suite la [PR 148](https://github.com/betagouv/competences-pro-serveur/pull/148) concernant la `Timezone`.