### PR TITLE
Spécifie la version de traefik utilisé.

### DIFF
--- a/traefik.yml
+++ b/traefik.yml
@@ -26,7 +26,7 @@
 
     - name: Démarre traefik
       docker_container:
-        image: traefik
+        image: traefik:v1.7
         name: traefik
         restart_policy: always
         pull: true


### PR DESCRIPTION
La v2 est sorti entre temps et il faut mettre à jour la config.