### PR TITLE
utilise les dépots eva et corrige le readme

### DIFF
--- a/deploiement.yml
+++ b/deploiement.yml
@@ -29,15 +29,15 @@
         force: yes
       loop:
         - destination: "{{ chemin_orchestrateur }}"
-          depot: competences-pro-orchestrateur
+          depot: eva-orchestrateur
           version: "{{ version_orchestrateur }}"
 
         - destination: "{{ chemin_serveur }}"
-          depot: competences-pro-serveur
+          depot: eva-serveur
           version: "{{ version_serveur }}"
 
         - destination: "{{ chemin_client }}"
-          depot: competences-pro
+          depot: eva
           version: "{{ version_client }}"
 
     - name: Copie le fichier d'environnement de production vers l'orchestrateur

--- a/site.yml
+++ b/site.yml
@@ -10,7 +10,7 @@
   tasks:
     - name: Clone ou met à jour le dépot
       git:
-        repo: "https://github.com/betagouv/competences-pro-www.git"
+        repo: "https://github.com/betagouv/eva-www.git"
         version: "master"
         dest: "{{ chemin_site }}"
         force: yes


### PR DESCRIPTION
des coquilles s'étaient sont filouteusement glissées. Nous les avons détectées et rétabli une situation normale.