### PR TITLE
Renomme compétence pro en eva dans le fichier .env.serveur

### DIFF
--- a/.env.serveur
+++ b/.env.serveur
@@ -5,7 +5,7 @@ DB_USER=postgres
 
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=
-POSTGRES_DB=competences-pro_development
+POSTGRES_DB=eva_development
 
 JETON_SERVEUR_ROLLBAR=
 HOTE_SERVEUR=api.localhost:4000


### PR DESCRIPTION
Je ne suis pas trop sur de l'usage de cette variable d'environnement, mais comme elle ne concerne manifestement que l’environnement de dev, j'ai renommé pour faire disparaitre `competences-pro`