### PR TITLE
Revert "Utilise la version 2.1 de la config de circleci."

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2
 jobs:
   build:
     docker:


### PR DESCRIPTION
Le fait de pousser un job avec l'api en version 2.1 n'est pas encore supporté: https://circleci.com/docs/api/#trigger-a-new-job