### PR TITLE
Correction des backups et documentation de la restauration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ Par défaut, l'application est déployé avec une instance de [Metabase][]. Vous
     GRANT CONNECT ON DATABASE <POSTGRES_DB> TO metabase;
     GRANT SELECT ON ALL TABLES IN SCHEMA public TO metabase;
 
+## Restauration de backups
+
+Pour restaurer un backup
+
+    docker cp backup.dump postgres:/root/
+    docker exec postgres pg_restore --username <nomutilisateur> --dbname <nombasededonnes> /root/backup.dump
+
 ## Licence
 
 Ce logiciel et son code source sont distribués sous [licence AGPL](https://www.gnu.org/licenses/why-affero-gpl.fr.html).

--- a/docker-compose-dev-base.yml
+++ b/docker-compose-dev-base.yml
@@ -34,7 +34,7 @@ services:
     image: postgres:11
 
   pgbackups:
-    image: prodrigestivill/postgres-backup-local
+    image: prodrigestivill/postgres-backup-local:11
     env_file:
       - .env.serveur
     volumes:

--- a/docker-compose-dev-base.yml
+++ b/docker-compose-dev-base.yml
@@ -45,7 +45,7 @@ services:
       - postgres
     environment:
       - POSTGRES_HOST=postgres
-      - POSTGRES_EXTRA_OPTS=-Z9 --schema=public --blobs --format=c
+      - POSTGRES_EXTRA_OPTS=-Z9 --blobs --format=c
       - SCHEDULE=@yearly
       - BACKUP_KEEP_DAYS=7
       - BACKUP_KEEP_WEEKS=4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - postgres
     environment:
       - POSTGRES_HOST=postgres
-      - POSTGRES_EXTRA_OPTS=-Z9 --schema=public --blobs --format=c
+      - POSTGRES_EXTRA_OPTS=-Z9 --blobs --format=c
       - SCHEDULE=@daily
       - BACKUP_KEEP_DAYS=7
       - BACKUP_KEEP_WEEKS=4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - postgres
 
   pgbackups:
-    image: prodrigestivill/postgres-backup-local
+    image: prodrigestivill/postgres-backup-local:11
     restart: always
     env_file:
       - .env.serveur.prod


### PR DESCRIPTION
- Tout les schéma de la base de données sont désormais sauvegardé (ce qui permet d'inclure les extensions)
- on spécifie la version 11 de postgres pour le backup 
- un peu de documentation pour restaurer un backup