### PR TITLE
Install lftp pour pouvoir copier les backups.

### DIFF
--- a/installation.yml
+++ b/installation.yml
@@ -132,6 +132,11 @@
         - software-properties-common
         - python-docker
 
+    - name: installe lftp pour copier les backups
+      apt:
+        name: lftp
+        update_cache: yes
+
     - name: ajoute la clef publique du dépot docker
       apt_key:
         id: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88


### PR DESCRIPTION
Contribue à https://github.com/betagouv/eva-orchestrateur/issues/9